### PR TITLE
Added isset() to line 173 since MongoCursor::info() doesn't return a 'bat

### DIFF
--- a/src/Mandango/Logger/LoggableMongoCursor.php
+++ b/src/Mandango/Logger/LoggableMongoCursor.php
@@ -170,7 +170,7 @@ class LoggableMongoCursor extends \MongoCursor
             if ($info['skip']) {
                 $log['skip'] = $info['skip'];
             }
-            if ($info['batchSize']) {
+            if (isset($info['batchSize'])) {
                 $log['batchSize'] = $info['batchSize'];
             }
             if (isset($info['query']['$hint'])) {


### PR DESCRIPTION
Added isset() to line 173 since MongoCursor::info() doesn't return a 'batchSize' key by default and it returns a notice error in dev environment.
