### PR TITLE
Multi inheritance

### DIFF
--- a/src/Mandango/Extension/Core.php
+++ b/src/Mandango/Extension/Core.php
@@ -3057,6 +3057,7 @@ EOF
 
                 if (isset($this->configClasses[$inheritableClass]["inheritance"]["class"])) {
                     $grandParentClass = $this->configClasses[$inheritableClass]["inheritance"]["class"];
+                    $configClass['_parent_events'] = array_merge($configClass['_parent_events'], $this->configClasses[$grandParentClass]['events']);
                     $this->configClasses[$grandParentClass]['inheritable']['values'][$value] = $class;
                 }
                 

--- a/src/Mandango/Extension/Core.php
+++ b/src/Mandango/Extension/Core.php
@@ -149,7 +149,7 @@ class Core extends Extension
             $this->repositorySaveMethodProcess();
             $this->repositoryDeleteMethodProcess();
             $this->repositoryEnsureIndexesMethodProcess();
-
+            $this->repositoryInheritanceMethodProcess();
             // query
             $this->queryAllMethodProcess();
             $this->queryCreateCursorMethodProcess();
@@ -2303,7 +2303,10 @@ EOF;
                 $value = $this->configClass['inheritance']['value'];
                 $codeHeader = <<<EOF
         \$isNew = \$this->isNew();
-        \$query = \$isNew ? array_merge(array('$field' => '$value'), parent::queryForSave()) : parent::queryForSave();
+        \$query = parent::queryForSave();
+        if (\$isNew) {
+            \$query['$field'] = '$value';
+        }
         \$reset = false;
 EOF;
             } else {
@@ -2368,12 +2371,26 @@ EOF
         $field = $this->configClass['inheritance']['field'];
         $value = $this->configClass['inheritance']['value'];
 
-        $method = new Method('public', 'count', 'array $query = array()', <<<EOF
+        $function = '';
+        if ($this->configClass['inheritable']) {
+            $function .= <<<EOF
+            
+        \$types = \$this->getTypes();
+        \$types[] = '$value';
+        \$query = array_merge(\$query, array('$field' => array('\$in' => \$types)));
+EOF;
+        } else {
+            $function .= <<<EOF
+            
         \$query = array_merge(\$query, array('$field' => '$value'));
-
+EOF;
+        }
+        $function .= <<<EOF
+        
         return parent::count(\$query);
-EOF
-        );
+EOF;
+                
+        $method = new Method('public', 'count', 'array $query = array()', $function);
         $method->setDocComment(<<<EOF
     /**
      * {@inheritdoc}
@@ -2392,12 +2409,25 @@ EOF
         $field = $this->configClass['inheritance']['field'];
         $value = $this->configClass['inheritance']['value'];
 
-        $method = new Method('public', 'remove', 'array $query = array()', <<<EOF
+        $function = '';
+        if ($this->configClass['inheritable']) {
+            $function .= <<<EOF
+
+        \$types = \$this->getTypes();
+        \$types[] = '$value';
+        \$query = array_merge(\$query, array('$field' => array('\$in' => \$types)));
+EOF;
+        } else {
+            $function .= <<<EOF
+
         \$query = array_merge(\$query, array('$field' => '$value'));
+EOF;
+        }
+        $function .= <<<EOF
 
         return parent::remove(\$query);
-EOF
-        );
+EOF;
+        $method = new Method('public', 'remove', 'array $query = array()',$function);
         $method->setDocComment(<<<EOF
     /**
      * {@inheritdoc}
@@ -2559,6 +2589,73 @@ EOF
      *
      * @param mixed \$documents A document or an array of documents.
      */
+EOF
+        );
+        $this->definitions['repository_base']->addMethod($method);
+    }
+
+    private function repositoryInheritanceMethodProcess()
+    {
+        if (!$this->configClass['inheritable']) {
+            return;
+        }
+
+        $property = new Property('protected', 'typeClasses', null);
+        $this->definitions['repository_base']->addProperty($property);
+
+        $method = new Method('public', 'getTypeClasses',null, <<<EOF
+        \$this->initTypeClasses();
+
+        return \$this->typeClasses;
+EOF
+        );
+        $this->definitions['repository_base']->addMethod($method);
+
+        $method = new Method('public', 'getTypeClass','$type', <<<EOF
+        \$this->initTypeClasses();
+
+        if (!\$this->hasType(\$type)) {
+            throw new \InvalidArgumentException(sprintf('The type "%s" does not exist.', \$type));
+        }
+
+        return \$this->typeClasses[\$type];
+EOF
+        );
+        $this->definitions['repository_base']->addMethod($method);
+
+        $method = new Method('public', 'getTypeForClass','$class', <<<EOF
+        \$this->initTypeClasses();
+
+        if (false === \$type = array_search(\$class, \$this->typeClasses)) {
+            throw new \InvalidArgumentException(sprintf('The class "%s" is not a type class.', \$class));
+        }
+
+        return \$type;
+EOF
+        );
+        $this->definitions['repository_base']->addMethod($method);
+
+        $method = new Method('public', 'getTypes',null, <<<EOF
+        \$this->initTypeClasses();
+
+        return array_keys(\$this->typeClasses);
+EOF
+        );
+        $this->definitions['repository_base']->addMethod($method);
+
+        $method = new Method('public', 'hasType','$type', <<<EOF
+        \$this->initTypeClasses();
+
+        return isset(\$this->typeClasses[\$type]);
+EOF
+        );
+        $this->definitions['repository_base']->addMethod($method);
+
+        $method = new Method('public', 'initTypeClasses',null, <<<EOF
+        if (null === \$this->typeClasses) {
+            \$metadata = \$this->getMandango()->getMetadata('$this->class');
+            \$this->typeClasses = \$metadata['inheritable']['values'];
+        }
 EOF
         );
         $this->definitions['repository_base']->addMethod($method);
@@ -2760,10 +2857,25 @@ EOF
 
         $field = $this->configClass['inheritance']['field'];
         $value = $this->configClass['inheritance']['value'];
-
-        $method = new Method('public', 'createCursor', '', <<<EOF
+        $function = <<<EOF
         \$criteria = \$savedCriteria = \$this->getCriteria();
+EOF;
+;
+        if ($this->configClass['inheritable']) {
+            $function .= <<<EOF
+
+        \$types = \$this->getRepository()->getTypes();
+        \$types[] = '$value';
+        \$criteria = array_merge(\$criteria, array('$field' => array('\$in' => \$types)));
+EOF;
+        } else {
+            $function .= <<<EOF
+
         \$criteria['$field'] = '$value';
+EOF;
+        }
+        $function .= <<<EOF
+
         \$this->criteria(\$criteria);
 
         \$cursor = parent::createCursor();
@@ -2771,8 +2883,8 @@ EOF
         \$this->criteria(\$savedCriteria);
 
         return \$cursor;
-EOF
-        );
+EOF;
+        $method = new Method('public', 'createCursor', '', $function);
         $method->setDocComment(<<<EOF
     /**
      * {@inheritdoc}
@@ -2943,6 +3055,11 @@ EOF
                 }
                 $this->configClasses[$inheritableClass]['inheritable']['values'][$value] = $class;
 
+                if (isset($this->configClasses[$inheritableClass]["inheritance"]["class"])) {
+                    $grandParentClass = $this->configClasses[$inheritableClass]["inheritance"]["class"];
+                    $this->configClasses[$grandParentClass]['inheritable']['values'][$value] = $class;
+                }
+                
                 $configClass['collection'] = $this->configClasses[$inheritableClass]['collection'];
                 $configClass['inheritance']['field'] = $inheritable['field'];
             }

--- a/tests/Mandango/Tests/Extension/CorePolymorphicReferencesTest.php
+++ b/tests/Mandango/Tests/Extension/CorePolymorphicReferencesTest.php
@@ -324,6 +324,7 @@ class CorePolymorphicReferencesTest extends TestCase
         $element = $this->mandango->create('Model\FormElement')->setLabel('foo');
         $this->assertSame(array(
             'label' => 'foo',
+            'type'  => 'formelement',
         ), $element->queryForSave());
         $element->save();
         $element->setLabel('bar');
@@ -335,8 +336,8 @@ class CorePolymorphicReferencesTest extends TestCase
 
         $textareaElement = $this->mandango->create('Model\TextareaFormElement')->setLabel('ups');
         $this->assertSame(array(
-            'type' => 'textarea',
             'label' => 'ups',
+            'type' => 'textarea',
         ), $textareaElement->queryForSave());
         $textareaElement->save();
         $textareaElement->setLabel('zam');

--- a/tests/Mandango/Tests/TestCase.php
+++ b/tests/Mandango/Tests/TestCase.php
@@ -39,12 +39,12 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (!static::$staticConnection) {
-            static::$staticConnection = new Connection($this->server, $this->dbName);
+            static::$staticConnection = new Connection($this->server, $this->dbName, array('profile' => 1));
         }
         $this->connection = static::$staticConnection;
 
         if (!static::$staticGlobalConnection) {
-            static::$staticGlobalConnection = new Connection($this->server, $this->dbName.'_global');
+            static::$staticGlobalConnection = new Connection($this->server, $this->dbName.'_global', array('profile' => 1));
         }
         $this->globalConnection = static::$staticGlobalConnection;
 

--- a/tests/Model/Element.php
+++ b/tests/Model/Element.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Model\Element document.
+ */
+class Element extends \Model\Base\Element
+{
+}

--- a/tests/Model/ElementQuery.php
+++ b/tests/Model/ElementQuery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Query of Model\Element document.
+ */
+class ElementQuery extends \Model\Base\ElementQuery
+{
+}

--- a/tests/Model/ElementRepository.php
+++ b/tests/Model/ElementRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Repository of Model\Element document.
+ */
+class ElementRepository extends \Model\Base\ElementRepository
+{
+}

--- a/tests/Model/TextElement.php
+++ b/tests/Model/TextElement.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Model\TextElement document.
+ */
+class TextElement extends \Model\Base\TextElement
+{
+}

--- a/tests/Model/TextElementQuery.php
+++ b/tests/Model/TextElementQuery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Query of Model\TextElement document.
+ */
+class TextElementQuery extends \Model\Base\TextElementQuery
+{
+}

--- a/tests/Model/TextElementRepository.php
+++ b/tests/Model/TextElementRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Repository of Model\TextElement document.
+ */
+class TextElementRepository extends \Model\Base\TextElementRepository
+{
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -267,14 +267,10 @@ $configClasses = array(
         ),
     ),
     // single inheritance
-    'Model\FormElement' => array(
+    'Model\Element' => array(
         'inheritable' => array('type' => 'single'),
         'fields' => array(
-            'label'   => 'string',
-            'default' => 'raw',
-        ),
-        'referencesOne' => array(
-            'author' => array('class' => 'Model\Author'),
+          'label'   => 'string',
         ),
         'referencesMany' => array(
             'categories' => array('class' => 'Model\Category'),
@@ -282,8 +278,21 @@ $configClasses = array(
         'embeddedsOne' => array(
             'source' => array('class' => 'Model\Source'),
         ),
-        'embeddedsMany' => array(
-            'comments' => array('class' => 'Model\Comment'),
+    ),
+    'Model\TextElement' => array(
+        'inheritance' => array('class' => 'Model\Element', 'value' => 'textelement'),
+        'fields' => array(
+          'htmltext'   => 'string',
+        ),
+    ),
+    'Model\FormElement' => array(
+        'inheritable' => array('type' => 'single'),
+        'inheritance' => array('class' => 'Model\Element', 'value' => 'formelement'),
+        'fields' => array(
+            'default' => 'raw',
+        ),
+        'referencesOne' => array(
+            'author' => array('class' => 'Model\Author'),
         ),
         'events' => array(
             'preInsert'  => array('elementPreInsert'),
@@ -292,6 +301,9 @@ $configClasses = array(
             'postUpdate' => array('elementPostUpdate'),
             'preDelete'  => array('elementPreDelete'),
             'postDelete' => array('elementPostDelete'),
+        ),
+        'embeddedsMany' => array(
+            'comments' => array('class' => 'Model\Comment'),
         ),
     ),
     'Model\TextareaFormElement' => array(


### PR DESCRIPTION
Hi Pablo,

We will probably need to talk through this one. Here is a quick YAML schema to show what I'm trying to do.

```
Model\Element:
    inheritable: { type: single }
    referencesOne:
        page: { class: Model\FormPage }

Model\FormElement:
    inheritable: { type: single }
    inheritance: { class: Model\Element, value: formelement }
    fields:
        label:      { type: string, validation: [NotBlank: ~, Type: string] }
        reference:  { type: string, validation: [Type: string] }
        help:       { type: string, validation: [Type: string] }
        isRequired: { type: boolean, default: false, validation: [Type: boolean] }

Model\InputTextElement:
    inheritance: { class: Model\FormElement, value: text }
    fields:
        isNumeric: { type: boolean, default: false, validation: [Type: boolean] }

Model\TextElement:
    inheritance: { class: Model\Element, value: htmltext }
    fields:
        text:      { type: string, validation: [NotBlank: ~, Type: string] }
```

I've added things to the tests to make sure we have got a little amount of coverage, also the tests are passing. They were failing with my first go at implementing this, so pleased with the amount of tests that let me do this! Nice one.
