### PR TITLE
spl_object_hash hashes can be reused when an object is destroyed, archive needs to be cleared 

### DIFF
--- a/src/Mandango/Document/AbstractDocument.php
+++ b/src/Mandango/Document/AbstractDocument.php
@@ -39,6 +39,14 @@ abstract class AbstractDocument
     }
 
     /**
+     * Destructor - empties the Archive cache
+     */
+    public function __destruct()
+    {
+        Archive::removeObject($this);
+    }
+
+    /**
      * Returns the mandango.
      *
      * @return Mandango The mandango.

--- a/src/Mandango/Group/AbstractGroup.php
+++ b/src/Mandango/Group/AbstractGroup.php
@@ -26,6 +26,14 @@ abstract class AbstractGroup implements \Countable, \IteratorAggregate
     private $saved;
 
     /**
+     * Destructor - empties the Archive cache
+     */
+    public function __destruct()
+    {
+        Archive::removeObject($this);
+    }
+
+    /**
      * Adds document/s to the add queue of the group.
      *
      * @param Mandango\Document\AbstractDocument|array $documents One or more documents.

--- a/tests/Mandango/Tests/Group/EmbeddedGroupTest.php
+++ b/tests/Mandango/Tests/Group/EmbeddedGroupTest.php
@@ -59,4 +59,16 @@ class EmbeddedGroupTest extends TestCase
         $group->setSavedData($data = array(array('foo' => 'bar'), array('bar' => 'foo')));
         $this->assertSame($data, $group->getSavedData());
     }
+    
+    public function testDuplicateSplObjectHash()
+    {
+        $group = new EmbeddedGroup('Model\Comment');
+        $comment = $this->mandango->create('Model\Comment');
+        $this->assertEquals(0, count($group->getAdd()));
+        $group->add($comment);
+        $this->assertEquals(1, count($group->getAdd()));
+        unset($group);
+        $group = new EmbeddedGroup('Model\Comment');
+        $this->assertEquals(0, count($group->getAdd()));
+    }
 }


### PR DESCRIPTION
http://www.php.net/manual/en/function.spl-object-hash.php says :

"When an object is destroyed, its hash may be reused for other objects"

Archive uses spl_object_cache, therefore cached values can bleed from one objet to another.

The pull request is now clean
