### PR TITLE
Bug with embedded document groups after save

### DIFF
--- a/tests/Mandango/Tests/Extension/CoreDocumentTest.php
+++ b/tests/Mandango/Tests/Extension/CoreDocumentTest.php
@@ -1861,4 +1861,38 @@ class CoreDocumentTest extends TestCase
         $source->clearEmbeddedsOneChanged();
         $this->assertFalse($source->isEmbeddedOneChanged('info'));
     }
+
+
+    public function testEmbeddedDocumentChangePropagatesToParentAfterSave()
+    {
+        $article = $this->mandango->create('Model\Article')->setDocumentData(array(
+            '_id' => new \MongoId('123'),
+            'comments' => array(
+                array(
+                    'name' => 'Default Name',
+                ),
+            ),
+        ));
+
+        // check the default name
+        foreach($article->getComments() as $modified_comment) { break; }
+        $this->assertEquals('Default Name', $modified_comment->getName());
+
+        // update the comment
+        foreach($article->getComments() as $comment_to_modify) { break; }
+        $comment_to_modify->setName('New Name');
+        $this->assertEquals('New Name', $comment_to_modify->getName());
+
+        // check that the embedded comment was updated in the article group BEFORE save
+        foreach($article->getComments() as $modified_comment) { break; }
+        $this->assertEquals('New Name', $modified_comment->getName());
+
+        // save
+        $article->save();
+
+        // check that the embedded comment was updated in the article AFTER save
+        foreach($article->getComments() as $modified_comment) { break; }
+        $this->assertEquals('New Name', $modified_comment->getName());
+    }
+
 }


### PR DESCRIPTION
Pablo - Here is a test that demonstrates a bug I discovered.

In short, embedded groups are not being updated in memory after its parent is saved.  I'd like to be able to contribute a fix at some point, but so far I've only been able to write a test that demonstrates the problem.

If you can point me in a direction, I can work on contributing a fix.
