### PR TITLE
Generator's infinite loop fix

### DIFF
--- a/src/Mandango/Extension/Core.php
+++ b/src/Mandango/Extension/Core.php
@@ -853,6 +853,9 @@ EOF
                      $hasReferences = true;
                  }
                  foreach (array_merge($configClass['embeddedsOne'], $configClass['embeddedsMany']) as $name => $embedded) {
+                     if ($embedded['class'] == $class) {
+                         continue;
+                     }
                      if (!isset($this->configClasses[$embedded['class']]['_has_references'])) {
                          $continue = true;
                          continue 2;
@@ -923,6 +926,9 @@ EOF
                     $hasGroups = true;
                 }
                 foreach (array_merge($configClass['embeddedsOne'], $configClass['embeddedsMany']) as $name => $embedded) {
+                    if ($embedded['class'] == $class) {
+                        continue;
+                    }
                     if (!isset($this->configClasses[$embedded['class']]['_has_groups'])) {
                         $continue = true;
                         continue 2;
@@ -947,6 +953,9 @@ EOF
 
                 $indexes = $configClass['indexes'];
                 foreach (array_merge($configClass['embeddedsOne'], $configClass['embeddedsMany']) as $name => $embedded) {
+                    if ($embedded['class'] == $class) {
+                        continue;
+                    }
                     if (!isset($this->configClasses[$embedded['class']]['_indexes'])) {
                         $continue = true;
                         continue 2;


### PR DESCRIPTION
When we try to generate classes for nested embedded documents:

``` php
'Model\Parent' => array(
        'fields' => array(
        'foo' => 'string',
    ),
    'embeddedsMany' => array(
        'nodes' => array('class' => 'Model\NestedChild'),
    ),
),
'Model\NestedChild' => array(
    'isEmbedded' => true,
    'fields' => array(
        'foo' => 'string',
    ),
    'embeddedsMany' => array(
        'nodes' => array('class' => 'Model\NestedChild'), # Self-emdebbed model cause an inifnite loop.
    ),
),
```

generator go into infinite loop.

This commit fix it.
