### PR TITLE
Fix for issue #28

### DIFF
--- a/src/Mandango/Extension/templates/Core/DocumentUpdateReferenceFields.php.twig
+++ b/src/Mandango/Extension/templates/Core/DocumentUpdateReferenceFields.php.twig
@@ -52,7 +52,9 @@
                     $ids[] = $document->getId();
                 }
                 foreach ($remove as $document) {
-                    unset($ids[array_search($document->getId(), $ids)]);
+                    if (false !== $key = array_search($document->getId(), $ids)) {
+                        unset($ids[$key]);
+                    }
                 }
                 $this->set{{ reference.field|ucfirst }}($ids ? array_values($ids) : null);
             }

--- a/tests/Mandango/Tests/Extension/CoreDocumentTest.php
+++ b/tests/Mandango/Tests/Extension/CoreDocumentTest.php
@@ -194,6 +194,23 @@ class CoreDocumentTest extends TestCase
         $this->assertSame($article, $article->removeCategories($category));
         $this->assertSame(array($category), $article->getCategories()->getRemove());
     }
+    
+    public function testReferencesManyRemove_RemoveNoneExistingDocumentDoesNothing()
+    {
+        $c1 = $this->mandango->create('Model\Category')->setName('c1')->save();
+        $c2 = $this->mandango->create('Model\Category')->setName('c2')->save();
+        $c3 = $this->mandango->create('Model\Category')->setName('c3')->save();
+        $c4 = $this->mandango->create('Model\Category')->setName('c4')->save();
+
+        $article = $this->mandango->create('Model\Article')->addCategories($c1)
+                ->addCategories($c2)->addCategories($c3)->save();
+        
+        $this->assertEquals(3, count($article->getCategories()));
+        
+        $article->removeCategories($c4)->save();
+        
+        $this->assertEquals(3, count($article->getCategories()));
+    }
 
     public function testUpdateReferenceFieldsReferencesOne()
     {


### PR DESCRIPTION
Fix for issue #28 : Removing a non referenced document used to delete the first document. Fixed in template such that it does nothing if the document is not referenced.
