### PR TITLE
fixed two typos in variable names

### DIFF
--- a/src/Mandango/Extension/Core.php
+++ b/src/Mandango/Extension/Core.php
@@ -720,7 +720,7 @@ EOF
                     // inherited
                     $inheritedFields = array_merge($inheritedFields, $this->configClasses[$parentInheritance['class']]['fields']);
                     $inheritedReferencesOne = array_merge($inheritedReferencesOne, $this->configClasses[$parentInheritance['class']]['referencesOne']);
-                    $inheritedReferencesMany = array_merge($inheritanceReferencesMany, $this->configClasses[$parentInheritance['class']]['referencesMany']);
+                    $inheritedReferencesMany = array_merge($inheritedReferencesMany, $this->configClasses[$parentInheritance['class']]['referencesMany']);
                     $inheritedEmbeddedsOne = array_merge($inheritedEmbeddedsOne, $this->configClasses[$parentInheritance['class']]['embeddedsOne']);
                     $inheritedEmbeddedsMany = array_merge($inheritedEmbeddedsMany, $this->configClasses[$parentInheritance['class']]['embeddedsMany']);
 
@@ -728,7 +728,7 @@ EOF
                         $inheritableClass = $parentInheritance['class'];
                         $inheritable = $this->configClasses[$parentInheritance['class']]['inheritable'];
                     } else {
-                        $continueSearchingInheritance = true;
+                        $continueSearchingInheritable = true;
                         $parentInheritance = $this->configClasses[$parentInheritance['class']]['inheritance'];
                     }
                 } while ($continueSearchingInheritable);


### PR DESCRIPTION
Hi Pablo,

I can't tell you when this causes an error, it's just very obvious that the one variable "$inheritanceReferencesMany" has a typo and the other "$continueSearchingInheritance" is also a typo or an error from refactoring, because the var is never used while "$continueSearchingInheritable" is there to break the while loop. I don't know your code good enough to understand when this code would be called an therefor fail.

Best regards, Anton
