### PR TITLE
Feature id to mongo

### DIFF
--- a/src/Mandango/Extension/templates/Core/Repository.php.twig
+++ b/src/Mandango/Extension/templates/Core/Repository.php.twig
@@ -185,7 +185,7 @@
                 $document->preUpdateEvent();
 {% endif %}
                 $query = $document->queryForSave();
-                $collection->update(array('_id' => $document->getId()), $query, $updateOptions);
+                $collection->update(array('_id' => $this->idToMongo($document->getId())), $query, $updateOptions);
                 $document->clearModified();
 {% if config_class._has_groups %}
                 $document->resetGroups();
@@ -213,7 +213,7 @@
 {% if config_class.events.preDelete or config_class._parent_events.preDelete %}
             $document->preDeleteEvent();
 {% endif %}
-            $ids[] = $id = $document->getId();
+            $ids[] = $id = $this->idToMongo($document->getId());
         }
 
         foreach ($documents as $document) {


### PR DESCRIPTION
Hi Pablo,

after playing with the idGenerators I think that this change makes sense. There are many cases where the MongoId will be changed to it's string representation, for example to use it in forms (or urls). The client code should not know about MongoIds so it will set the _id to the string. The way idToMongo() works this is totally fine and save. :-) I have added my unit tests, all other unit tests still run.

Best regards, Anton
