### PR TITLE
Properly map field names

### DIFF
--- a/src/Mandango/Query.php
+++ b/src/Mandango/Query.php
@@ -560,6 +560,25 @@ abstract class Query implements \Countable, \IteratorAggregate
         return $this->createCursor()->count();
     }
 
+    protected function mapFieldNames(array $fields = array())
+    {
+        $mandango = $this->getRepository()->getMandango();
+        $metadata = $mandango->getMetadataFactory()->getClass($this->getRepository()->getDocumentClass());
+
+        $mapper = function ($name) use ($metadata) {
+            $parts = explode('.', $name);
+
+            foreach ($parts as &$part) {
+                $part = (isset($metadata['fields'][$part]['dbName']) ? $metadata['fields'][$part]['dbName'] : $part);
+            }
+
+            return implode('.', $parts);
+        };
+
+        $dbNames = array_map($mapper, array_keys($fields));
+        return array_combine($dbNames, $fields);
+    }
+
     /**
      * Create a cursor with the data of the query.
      *
@@ -567,10 +586,14 @@ abstract class Query implements \Countable, \IteratorAggregate
      */
     public function createCursor()
     {
-        $cursor = $this->repository->getCollection()->find($this->criteria, $this->fields);
+
+        $cursor = $this->repository->getCollection()->find(
+            $this->mapFieldNames($this->criteria),
+            $this->mapFieldNames($this->fields)
+        );
 
         if (null !== $this->sort) {
-            $cursor->sort($this->sort);
+            $cursor->sort($this->mapFieldNames($this->sort));
         }
 
         if (null !== $this->limit) {

--- a/src/Mandango/Query.php
+++ b/src/Mandango/Query.php
@@ -562,6 +562,10 @@ abstract class Query implements \Countable, \IteratorAggregate
 
     protected function mapFieldNames(array $fields = array())
     {
+        if (empty($fields)) {
+            return array();
+        }
+
         $mandango = $this->getRepository()->getMandango();
         $metadata = $mandango->getMetadataFactory()->getClass($this->getRepository()->getDocumentClass());
 


### PR DESCRIPTION
Remap names to dbNames on criteria/fields/sort cursor options.

When setting fields for $query->sort() dbnames must be used instead of normaln names. This makes for inconsistent code where you have to use different names for different use cases:

``` php
// normal name
$document->getProperty() 
// dbname
$query->sort([ 'prop' => 1 ]);
```

This is referenced in https://github.com/NextWebVentures/mandango/issues/3.
