### PR TITLE
Fix connection

### DIFF
--- a/src/Mandango/Connection.php
+++ b/src/Mandango/Connection.php
@@ -189,7 +189,7 @@ class Connection implements ConnectionInterface
                     $this->mongo->setLogDefault($this->logDefault);
                 }
             } else {
-                $this->mongo = new \Mongo($this->server, $this->options);
+                $this->mongo = new \MongoClient($this->server, $this->options);
             }
         }
 

--- a/src/Mandango/Connection.php
+++ b/src/Mandango/Connection.php
@@ -189,7 +189,13 @@ class Connection implements ConnectionInterface
                     $this->mongo->setLogDefault($this->logDefault);
                 }
             } else {
-                $this->mongo = new \MongoClient($this->server, $this->options);
+                $this->mongo = null;
+                if(class_exists('MongoClient')){
+                    $this->mongo = new \MongoClient($this->server, $this->options);
+                }
+                else{
+                    $this->mongo = new \Mongo($this->server, $this->options);
+                }
             }
         }
 


### PR DESCRIPTION
Mongo class is deprecated in PECL < 1.3.0 I've changed client to work with both version without deprecation warning.
