### PR TITLE
Fix for issue #51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mandango/mandango",
+    "name": "netom/mandango",
     "type": "library",
     "description": "Simple, poweful and ultrafast Object Document Mapper (ODM) for PHP and MongoDB",
     "keywords": ["odm", "mongodb"],
@@ -7,13 +7,17 @@
     "license": "MIT",
     "authors": [
         {
+            "name":  "Fábián Tamás László",
+            "email": "giganetom@gmail.com"
+        },
+        {
             "name":  "Pablo Díez",
             "email": "pablodip@gmail.com"
         }
     ],
     "require": {
         "php":               ">=5.3.0",
-        "mandango/mondator": "1.0.*@dev"
+        "netom/mondator": "1.0.*@dev"
     },
     "require-dev": {
 	"phpunit/phpunit": "~3.7"

--- a/src/Mandango/Extension/templates/Core/Query.php.twig
+++ b/src/Mandango/Extension/templates/Core/Query.php.twig
@@ -29,7 +29,7 @@
             }
             $f =& $fields;
             foreach (explode('.', $field) as $name) {
-                if (!isset($f[$name])) {
+                if (!isset($f[$name]) || !is_array($f[$name])) {
                     $f[$name] = array();
                 }
                 $f =& $f[$name];

--- a/src/Mandango/Query.php
+++ b/src/Mandango/Query.php
@@ -567,7 +567,7 @@ abstract class Query implements \Countable, \IteratorAggregate
      */
     public function createCursor()
     {
-        $cursor = $this->repository->getCollection()->find($this->criteria, $this->fields);
+        $cursor = $this->repository->getCollection()->find($this->criteria, []);
 
         if (null !== $this->sort) {
             $cursor->sort($this->sort);


### PR DESCRIPTION
The getFields() function can return a field name like "a", and if that field is an array of embedded documents, it will return something like "a.0.b" too. This way the $f[$field] can either be undefined, int(1), or an array. The original check fails to recognize the second condition. This proposed modification fixes this issue.
